### PR TITLE
Feature/preserve taken slots

### DIFF
--- a/laravel/app/Http/Controllers/AdminController.php
+++ b/laravel/app/Http/Controllers/AdminController.php
@@ -24,9 +24,24 @@ class AdminController extends Controller
     }
     
     // List of users
-    function userList()
+    function userList(Request $request)
     {
         $users = User::paginate(100);
+
+        if($request->query('search'))
+        {
+            $search = $request->query('search');
+
+            if(is_numeric($search))
+            {
+                $users = [User::find($search)];
+            }
+            else
+            {
+                $users = User::where('name', 'like', "%{$search}%")->orWhere('email', 'like', "%{$search}%")->get();
+            }
+        }
+
         return view('pages/admin/user-list', compact('users'));
     }
 

--- a/laravel/app/Http/routes.php
+++ b/laravel/app/Http/routes.php
@@ -89,6 +89,7 @@ Route::post('/slot/{slot}/release', 'SlotController@release');
 Route::group(['middleware' => ['auth','admin']], function()
 {
     Route::post('/slot/{slot}/edit','SlotController@edit');
+    Route::post('/slot/{slot}/adminRelease', 'SlotController@adminRelease');
 });
 
 // User profile routes

--- a/laravel/app/Models/Slot.php
+++ b/laravel/app/Models/Slot.php
@@ -64,7 +64,7 @@ class Slot extends Model
         else
         {
             // Delete all existing slots for this shift
-            Slot::where('schedule_id', $schedule->id)->delete();
+            Slot::whereNull('user_id')->delete();
             $row = 1;
         }
 

--- a/laravel/resources/views/pages/admin/user-list.blade.php
+++ b/laravel/resources/views/pages/admin/user-list.blade.php
@@ -1,8 +1,14 @@
 @extends('app')
 
 @section('content')
-    <h1>Registered Users</h1>
+    <h1>Registered Users </h1>
     <hr>
+    <form class="input-group user-search" method="GET" action="/users">
+        <input type="text" name="search" class=" form-control" placeholder="search by email or username">
+        <div class="input-group-btn">
+            <button type="submit" class=" btn btn-primary"><span class="glyphicon glyphicon-search" aria-hidden="true"></span></button>
+        </div>
+    </form>
 
     <table class="table table-hover">
         <thead>
@@ -29,7 +35,7 @@
             @endforeach
         </tbody>
     </table>
-
+@if($users instanceof \Illuminate\Pagination\LengthAwarePaginator)
 {{ $users->links() }}
-
+@endif()
 @endsection

--- a/laravel/resources/views/pages/slot/view.blade.php
+++ b/laravel/resources/views/pages/slot/view.blade.php
@@ -9,7 +9,6 @@ $other = false;
 if(!empty($slot->user))
 {
     $taken = true;
-
     if(Auth::check() && Auth::user()->id == $slot->user->id)
     {
         $self = true;
@@ -18,6 +17,10 @@ if(!empty($slot->user))
     else
     {
         $other = true;
+    }
+    if (Auth::check() && Auth::user()->hasRole('admin'))
+    {
+        $url = "/slot/{$slot->id}/adminRelease";
     }
 }
 
@@ -154,5 +157,13 @@ if(!empty($slot->user))
         @endif
 
         <a href="/event/{{ $slot->event->id }}" class="btn btn-primary">Back to Event</a>
+
+        @if(Auth::user()->hasRole('admin')&& $taken==true)
+        <p>
+            Are you sure you want to remove this user for this shift?
+            By releasing {{$slot->user->data->burner_name}}, their slot will be available for other people to take.
+        </p>
+        <button type="submit" class="btn btn-danger">Release Shift</button>
+        @endif
     {!! Form::close() !!}
 @endsection


### PR DESCRIPTION
the fix is simple but much could be done to enhance this. for one, if you're changing user slots a new set of slots will over lap the current ones making the slots appear they were deleted, however, if you move them, the slots that appeared to be deleted will be visible. the same thing happens when you edit an existing slot and try to move the times rather than add or remove volunteers.