### PR TITLE
Fix for issue #130 - render all days in event view with a shift scheduled

### DIFF
--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -110,7 +110,7 @@ class Event extends Model
             if($hideEmpty)
             {
                 // get an array of all the dates fields for this event
-                $shift_dates = Schedule::whereIn('shift_id', $this->shifts->pluck('id')->pluck('dates'));
+                $shift_dates = Schedule::whereIn('shift_id', $this->shifts->pluck('id'))->pluck('dates');
                 $merged_dates = [];
                 //iterate through scheduled dates and merge them into one list
                 foreach ($shift_dates as $i) {

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -110,11 +110,11 @@ class Event extends Model
             if($hideEmpty)
             {
                 // get an array of all the dates fields for this event
-                $shift_dates = Schedule::whereIn('shift_id', $this->shifts->pluck('dates'));
+                $shift_dates = Schedule::whereIn('shift_id', $this->shifts->pluck('id')->pluck('dates'));
                 $merged_dates = [];
                 //iterate through scheduled dates and merge them into one list
                 foreach ($shift_dates as $i) {
-                    $merged_dates = array_merge($merged_dates, $i);
+                    $merged_dates = array_merge($merged_dates, json_decode($i));
                 }
                 // remove duplicate dates
                 $shift_dates = array_unique( $merged_dates );
@@ -128,7 +128,7 @@ class Event extends Model
                 if($hideEmpty)
                 {
                     // check to see if the current day is in the list of shift_dates we prepared earlier
-                    if(in_array( $date->format('Y-m-d'), $shift_dates ))
+                    if(!in_array( $date->format('Y-m-d'), $shift_dates ))
                     {
                         // Continue onto the next day
                         $date->addDay();

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -106,15 +106,29 @@ class Event extends Model
         // This only works when the start date is before the end date
         if($start_date->lte($end_date))
         {
-            // $date keeps track of the current date as we loop towards the end
+            // do this once
+            if($hideEmpty)
+            {
+                // get an array of all the dates fields for this event
+                $shift_dates = Schedule::whereIn('shift_id', $this->shifts->pluck('dates'));
+                $merged_dates = [];
+                //iterate through scheduled dates and merge them into one list
+                foreach ($shift_dates as $i) {
+                    $merged_dates = array_merge($merged_dates, $i);
+                }
+                // remove duplicate dates
+                $shift_dates = array_unique( $merged_dates );
+            }
+            
+			// $date keeps track of the current date as we loop towards the end
             $date = $start_date;
 
             while($date->lte($end_date))
             {
                 if($hideEmpty)
                 {
-                    // Pluck all of the shift IDs for this event and check the if any in the schedule start today
-                    if(Schedule::whereIn('shift_id', $this->shifts->pluck('id'))->where('start_date', $date->format('Y-m-d'))->get()->isEmpty())
+                    // check to see if the current day is in the list of shift_dates we prepared earlier
+                    if(in_array( $date->format('Y-m-d'), $shift_dates ))
                     {
                         // Continue onto the next day
                         $date->addDay();

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -120,7 +120,7 @@ class Event extends Model
                 $shift_dates = array_unique( $merged_dates );
             }
             
-			// $date keeps track of the current date as we loop towards the end
+            // $date keeps track of the current date as we loop towards the end
             $date = $start_date;
 
             while($date->lte($end_date))

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -146,16 +146,48 @@ class Schedule extends Model
 
         return $input;
     }
-
     // Helper function to format timestamps before displaying them in forms
-    public function formatTimes()
-    {
-        $start = date_parse_from_format('H:i', $this->start_time);
-        $end = date_parse_from_format('H:i', $this->end_time);
-        $duration = date_parse_from_format('H:i', $this->duration);
-
-        $this->start_time = str_pad($start['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
-        $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
-        $this->duration = str_pad($duration['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
+        public function formatTimes()
+        {
+            $start = date_parse_from_format('H:i', $this->start_time);
+            $end = date_parse_from_format('H:i', $this->end_time);
+            $duration = date_parse_from_format('H:i', $this->duration);
+            if ($start['hour'] < 10 )
+            $this->start_time = $this->formatStartHour($start['hour']) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
+            $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
+            $this->duration = $this->formatDurationHour($duration['hour']) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
+        }
+    
+        // this handles a corner case where validation requires times formatted HH:MM but 
+        // javascript is detecting custom values based on Carbon formatted times
+        // This causes custom values for start_time to be clobbered by the form population
+        // when the Schedule edit view is loaded or validation to reject custom values for 
+        // Duration because they're formatted as H:MM for single digit values.
+        // If we zero pad the hour, custom values are fine, but pre-populated values (6 AM)
+        // are detected as a custom value. So, we have to zero pad hour values under 10, 
+        // exempting 6 and 9. Except that duration's custom values that would be affected
+        // are 3, and 6. So we split them into two functions. Good grief.
+        private function formatStartHour($h) 
+        {
+            if ( (!in_array($h, [6,9]) ) and ($h < 10) ) 
+            {
+                return str_pad($h, 2, 0, STR_PAD_LEFT);
+            }
+            else 
+            {
+                return $h;
+            }
+        }
+    
+        private function formatDurationHour($h) 
+        {
+            if ( (!in_array($h, [3,6]) ) and ($h < 10) ) 
+            {
+                return str_pad($h, 2, 0, STR_PAD_LEFT);
+            }
+            else 
+            {
+                return $h;
+            }
+        }
     }
-}

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -146,48 +146,49 @@ class Schedule extends Model
 
         return $input;
     }
+    
     // Helper function to format timestamps before displaying them in forms
-        public function formatTimes()
+    public function formatTimes()
+    {
+        $start = date_parse_from_format('H:i', $this->start_time);
+        $end = date_parse_from_format('H:i', $this->end_time);
+        $duration = date_parse_from_format('H:i', $this->duration);
+        
+        $this->start_time = $this->formatStartHour($start['hour']) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
+        $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
+        $this->duration = $this->formatDurationHour($duration['hour']) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
+    }
+
+    // this handles a corner case where validation requires times formatted HH:MM but 
+    // javascript is detecting custom values based on Carbon formatted times
+    // This causes custom values for start_time to be clobbered by the form population
+    // when the Schedule edit view is loaded or validation to reject custom values for 
+    // Duration because they're formatted as H:MM for single digit values.
+    // If we zero pad the hour, custom values are fine, but pre-populated values (6 AM)
+    // are detected as a custom value. So, we have to zero pad hour values under 10, 
+    // exempting 6 and 9. Except that duration's custom values that would be affected
+    // are 3, and 6. So we split them into two functions. Good grief.
+    private function formatStartHour($h) 
+    {
+        if ( (!in_array($h, [6,9]) ) and ($h < 10) ) 
         {
-            $start = date_parse_from_format('H:i', $this->start_time);
-            $end = date_parse_from_format('H:i', $this->end_time);
-            $duration = date_parse_from_format('H:i', $this->duration);
-            
-            $this->start_time = $this->formatStartHour($start['hour']) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
-            $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
-            $this->duration = $this->formatDurationHour($duration['hour']) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
+            return str_pad($h, 2, 0, STR_PAD_LEFT);
         }
-    
-        // this handles a corner case where validation requires times formatted HH:MM but 
-        // javascript is detecting custom values based on Carbon formatted times
-        // This causes custom values for start_time to be clobbered by the form population
-        // when the Schedule edit view is loaded or validation to reject custom values for 
-        // Duration because they're formatted as H:MM for single digit values.
-        // If we zero pad the hour, custom values are fine, but pre-populated values (6 AM)
-        // are detected as a custom value. So, we have to zero pad hour values under 10, 
-        // exempting 6 and 9. Except that duration's custom values that would be affected
-        // are 3, and 6. So we split them into two functions. Good grief.
-        private function formatStartHour($h) 
+        else 
         {
-            if ( (!in_array($h, [6,9]) ) and ($h < 10) ) 
-            {
-                return str_pad($h, 2, 0, STR_PAD_LEFT);
-            }
-            else 
-            {
-                return $h;
-            }
-        }
-    
-        private function formatDurationHour($h) 
-        {
-            if ( (!in_array($h, [3,6]) ) and ($h < 10) ) 
-            {
-                return str_pad($h, 2, 0, STR_PAD_LEFT);
-            }
-            else 
-            {
-                return $h;
-            }
+            return $h;
         }
     }
+
+    private function formatDurationHour($h) 
+    {
+        if ( (!in_array($h, [3,6]) ) and ($h < 10) ) 
+        {
+            return str_pad($h, 2, 0, STR_PAD_LEFT);
+        }
+        else 
+        {
+            return $h;
+        }
+    }
+}

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -146,14 +146,14 @@ class Schedule extends Model
 
         return $input;
     }
-    
+
     // Helper function to format timestamps before displaying them in forms
     public function formatTimes()
     {
         $start = date_parse_from_format('H:i', $this->start_time);
         $end = date_parse_from_format('H:i', $this->end_time);
         $duration = date_parse_from_format('H:i', $this->duration);
-        
+
         $this->start_time = $this->formatStartHour($start['hour']) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
         $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
         $this->duration = $this->formatDurationHour($duration['hour']) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -154,41 +154,8 @@ class Schedule extends Model
         $end = date_parse_from_format('H:i', $this->end_time);
         $duration = date_parse_from_format('H:i', $this->duration);
 
-        $this->start_time = $this->formatStartHour($start['hour']) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
+        $this->start_time = $start['hour'] . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
         $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
-        $this->duration = $this->formatDurationHour($duration['hour']) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
-    }
-
-    // this handles a corner case where validation requires times formatted HH:MM but 
-    // javascript is detecting custom values based on Carbon formatted times
-    // This causes custom values for start_time to be clobbered by the form population
-    // when the Schedule edit view is loaded or validation to reject custom values for 
-    // Duration because they're formatted as H:MM for single digit values.
-    // If we zero pad the hour, custom values are fine, but pre-populated values (6 AM)
-    // are detected as a custom value. So, we have to zero pad hour values under 10, 
-    // exempting 6 and 9. Except that duration's custom values that would be affected
-    // are 3, and 6. So we split them into two functions. Good grief.
-    private function formatStartHour($h) 
-    {
-        if ( (!in_array($h, [6,9]) ) and ($h < 10) ) 
-        {
-            return str_pad($h, 2, 0, STR_PAD_LEFT);
-        }
-        else 
-        {
-            return $h;
-        }
-    }
-
-    private function formatDurationHour($h) 
-    {
-        if ( (!in_array($h, [3,6]) ) and ($h < 10) ) 
-        {
-            return str_pad($h, 2, 0, STR_PAD_LEFT);
-        }
-        else 
-        {
-            return $h;
-        }
+        $this->duration = $duration['hour'] . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
     }
 }

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -152,7 +152,7 @@ class Schedule extends Model
             $start = date_parse_from_format('H:i', $this->start_time);
             $end = date_parse_from_format('H:i', $this->end_time);
             $duration = date_parse_from_format('H:i', $this->duration);
-            if ($start['hour'] < 10 )
+            
             $this->start_time = $this->formatStartHour($start['hour']) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
             $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
             $this->duration = $this->formatDurationHour($duration['hour']) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -154,8 +154,8 @@ class Schedule extends Model
         $end = date_parse_from_format('H:i', $this->end_time);
         $duration = date_parse_from_format('H:i', $this->duration);
 
-        $this->start_time = $start['hour'] . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
+        $this->start_time = str_pad($start['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
         $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
-        $this->duration = $duration['hour'] . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
+        $this->duration = str_pad($duration['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
     }
 }


### PR DESCRIPTION
My approach is to pluck all of the dates from the event's scheduled shifts, merge and remove duplicates on that list to make a list of dates (formatted "Y-m-d"). Then within the loop to return the days, we test for the current $date's presence in that list of shift_dates.

There may be issues at very large scale, but I imagine this will function quite well for most events. 

P.S. this is my first pull request on github ever!