### PR TITLE
fixed admin being unable to take shift

### DIFF
--- a/laravel/app/Http/Controllers/SlotController.php
+++ b/laravel/app/Http/Controllers/SlotController.php
@@ -51,6 +51,10 @@ class SlotController extends Controller
             {
                 $allowed = true;
             }
+            if ($user->hasRole('admin')) 
+            {
+                $allowed = true;
+            }
         }
 
         return $allowed;

--- a/laravel/resources/views/pages/slot/view.blade.php
+++ b/laravel/resources/views/pages/slot/view.blade.php
@@ -161,7 +161,11 @@ else
                 Please arrive at least 15 minutes ahead of time to be briefed by the previous shift team and answer any questions you have.
             </p>
 
+            @if(!(Auth::user()->hasRole('admin') || Auth::user()->hasRole('department-lead')))
             <button type="submit" class="btn btn-success">Take Shift</button>
+            @else
+            <button formaction="/slot/{{$slot->id}}/take" type="submit" class="btn btn-success">Take Shift</button>
+            @endif
         @endif
 
         <a href="/event/{{ $slot->event->id }}" class="btn btn-primary">Back to Event</a>


### PR DESCRIPTION
at first I figured out I could add a button attribute to change the url that needed to be changed as it was originally pointing to adminAssign. really we could get rid of the top portion of the code that keeps track of the url variable, and just add an attribute to our buttons and simplify the code a bit.

after which i ran into another problem which is the admin can't assign themselves to whatever they wanted on the take method, added a conditional there to allow for that, department leads my still have issues if they aren't listed as the appropriate roles for the shift.