### PR TITLE
Fix admins being unable to take shifts

### DIFF
--- a/laravel/resources/views/pages/slot/view.blade.php
+++ b/laravel/resources/views/pages/slot/view.blade.php
@@ -166,7 +166,7 @@ else
 
         <a href="/event/{{ $slot->event->id }}" class="btn btn-primary">Back to Event</a>
 
-        @if((Auth::user()->hasRole('admin') || Auth::user()->hasRole('department-lead')) && $taken)
+        @if((Auth::user()->hasRole('admin') || Auth::user()->hasRole('department-lead')) && $taken && $other)
         <p>
             Are you sure you want to remove this user for this shift?
             By releasing {{$slot->user->data->burner_name}}, their slot will be available for other people to take.
@@ -177,20 +177,21 @@ else
             <a class="btn btn-warning add-volunteer">Add Volunteer</a>
             <input type="hidden" class="csrf-token" name="_token" value="{{ csrf_token() }}">
             <div class="row user-search hidden">
-                    <div class="col-md-11">
-                        @include('partials/form/text',
-                        [
-                            'name' => 'user-search',
-                            'label' => 'Search for a user',
-                            'placeholder' => 'rachel@apogaea.com',
-                            'help' => 'You can search by user ID, username, or email'
-                        ])
-                    </div>
+                <div class="col-md-11">
+                    @include('partials/form/text',
+                    [
+                        'name' => 'user-search',
+                        'label' => 'Search for a user',
+                        'placeholder' => 'rachel@apogaea.com',
+                        'help' => 'You can search by user ID, username, or email'
+                    ])
+                </div>
 
-                    <div class="col-md-1 search">
-                        <button class="user-search btn btn-success"><i class="glyphicon glyphicon-search"></i></button>
-                    </div>
+                <div class="col-md-1 search">
+                    <button class="user-search btn btn-success"><i class="glyphicon glyphicon-search"></i></button>
+                </div>
             </div>
+
             <div class="user-wrap">
                 <div class="loading hidden">
                     Loading user data...

--- a/laravel/resources/views/pages/slot/view.blade.php
+++ b/laravel/resources/views/pages/slot/view.blade.php
@@ -21,14 +21,14 @@ if(!empty($slot->user))
 
     if(Auth::check() && (Auth::user()->hasRole('admin') || Auth::user()->hasRole('department-lead')))
     {
-        $url = "/slot/{$slot->id}/adminRelease";
+        $adminUrl = "/slot/{$slot->id}/adminRelease";
     }
 }
 else
 {
     if(Auth::check() && Auth::user()->hasRole('admin') || Auth::user()->hasRole('department-lead'))
     {
-        $url = "/slot/{$slot->id}/adminAssign";
+        $adminUrl = "/slot/{$slot->id}/adminAssign";
     }
 }
 
@@ -171,7 +171,7 @@ else
             Are you sure you want to remove this user for this shift?
             By releasing {{$slot->user->data->burner_name}}, their slot will be available for other people to take.
         </p>
-        <button type="submit" class="btn btn-danger">Release Shift</button>
+        <button formaction="{{ $adminUrl }}" type="submit" class="btn btn-danger">Release Shift</button>
         @endif
         @if((Auth::user()->hasRole('admin') || Auth::user()->hasRole('department-lead')) && !$taken)
             <a class="btn btn-warning add-volunteer">Add Volunteer</a>
@@ -248,7 +248,7 @@ else
                             </tr>
                         </tbody>
                     </table>
-                    <button style="text-align: right;" class="btn btn-primary" type="submit">Assign User</button>
+                    <button formaction="{{ $adminUrl }}" class="btn btn-primary" type="submit">Assign User</button>
                 </div>
             </div>
         @endif


### PR DESCRIPTION
The default form action was being overwritten for admins and department leads when trying to click the "take" / "release" button on the slots page. This bug was introduced by the feature to allow admins to add and remove users from shifts but wasn't caught during code review.

This was fixed by creating separate "url" and "adminUrl" variables for the default button and the admin button. 

- Changed admin buttons to use "formaction" attribute to preserve default form behavior 
- Removed unnecessary inline style from button
- Minor indenting fix

This PR fixes #141 and closes #142