### PR TITLE
fixed date format to prepend a zero if the hours are less than 10

### DIFF
--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -154,16 +154,8 @@ class Schedule extends Model
         $end = date_parse_from_format('H:i', $this->end_time);
         $duration = date_parse_from_format('H:i', $this->duration);
 
-        //check for any default start hours and if there are, don't pad start hours
-        (!in_array($start['hour'], [0,6,9,12,24])) ?
-        $this->start_time = str_pad($start['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT) :
-        $this->start_time = $start['hour'] . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
-        
-        //check for any default duration hours and if there are, don't pad duration hours
-        (!in_array( $duration['hour'], [3,6])) ?
-        $this->duration = str_pad($duration['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT) :
-        $this->duration = $duration['hour'] . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
-
+        $this->start_time = str_pad($start['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
+        $this->duration = str_pad($duration['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
         $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
     }
 }

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -154,8 +154,12 @@ class Schedule extends Model
         $end = date_parse_from_format('H:i', $this->end_time);
         $duration = date_parse_from_format('H:i', $this->duration);
 
+        ($start['hour']<10) ? $this->start_time = '0'.$start['hour'] . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT) :
         $this->start_time = $start['hour'] . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
-        $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
+
+        ($duration['hour']<10) ? $this->duration = '0'.$duration['hour'] . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT) : 
         $this->duration = $duration['hour'] . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
+
+        $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
     }
 }

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -154,12 +154,8 @@ class Schedule extends Model
         $end = date_parse_from_format('H:i', $this->end_time);
         $duration = date_parse_from_format('H:i', $this->duration);
 
-        ($start['hour']<10) ? $this->start_time = '0'.$start['hour'] . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT) :
-        $this->start_time = $start['hour'] . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
-
-        ($duration['hour']<10) ? $this->duration = '0'.$duration['hour'] . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT) : 
-        $this->duration = $duration['hour'] . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
-
+        $this->start_time = str_pad($start['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
+        $this->duration = str_pad($duration['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
         $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
     }
 }

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -147,15 +147,23 @@ class Schedule extends Model
         return $input;
     }
 
-    // Helper function to format timestamps before displaying them in forms
+    // Helper function to format timestamps before submitting them to the server
     public function formatTimes()
     {
         $start = date_parse_from_format('H:i', $this->start_time);
         $end = date_parse_from_format('H:i', $this->end_time);
         $duration = date_parse_from_format('H:i', $this->duration);
 
-        $this->start_time = str_pad($start['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
-        $this->duration = str_pad($duration['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
+        //check for any default start hours and if there are, don't pad start hours
+        (!in_array($start['hour'], [0,6,9,12,24])) ?
+        $this->start_time = str_pad($start['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT) :
+        $this->start_time = $start['hour'] . ":" . str_pad($start['minute'], 2, 0, STR_PAD_LEFT);
+        
+        //check for any default duration hours and if there are, don't pad duration hours
+        (!in_array( $duration['hour'], [3,6])) ?
+        $this->duration = str_pad($duration['hour'], 2, 0, STR_PAD_LEFT) . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT) :
+        $this->duration = $duration['hour'] . ":" . str_pad($duration['minute'], 2, 0, STR_PAD_LEFT);
+
         $this->end_time = $end['hour'] . ":" . str_pad($end['minute'], 2, 0, STR_PAD_LEFT);
     }
 }

--- a/laravel/resources/js/ui/schedule.js
+++ b/laravel/resources/js/ui/schedule.js
@@ -67,19 +67,6 @@ $(document).ready(function()
         }
     });
 
-    //format duration fields on the fly when the server can't
-    $('#duration-field').on('change', function()
-    {
-        if ($(this).value() == 'custom')
-        {
-            var currentVal = $('input[name=custom_duration]').value();
-            if(currentVal.length<5)
-            {   
-                $('input[name=custom_duration]').value('0'+currentVal); 
-            }
-        }
-    });
-
     $('.edit-schedule input[name="does-slot-repeat"]').on('change', function()
     {
         let slotRepeat = document.querySelector('.slot-repeat');

--- a/laravel/resources/js/ui/schedule.js
+++ b/laravel/resources/js/ui/schedule.js
@@ -67,6 +67,19 @@ $(document).ready(function()
         }
     });
 
+    //format duration fields on the fly when the server can't
+    $('#duration-field').on('change', function()
+    {
+        if ($(this).value() == 'custom')
+        {
+            var currentVal = $('input[name=custom_duration]').value();
+            if(currentVal.length<5)
+            {   
+                $('input[name=custom_duration]').value('0'+currentVal); 
+            }
+        }
+    });
+
     $('.edit-schedule input[name="does-slot-repeat"]').on('change', function()
     {
         let slotRepeat = document.querySelector('.slot-repeat');

--- a/laravel/resources/views/pages/schedule/edit.blade.php
+++ b/laravel/resources/views/pages/schedule/edit.blade.php
@@ -94,9 +94,9 @@ foreach($schedule->event->days() as $day)
                     'options' =>
                     [
                         '' => 'Select a time',
-                        '0:00' => 'Midnight (beginning of day)',
-                        '6:00' => '6 AM',
-                        '9:00' => '9 AM',
+                        '00:00' => 'Midnight (beginning of day)',
+                        '06:00' => '6 AM',
+                        '09:00' => '9 AM',
                         '12:00' => 'Noon',
                         'custom' => 'Other'
                     ],
@@ -117,8 +117,8 @@ foreach($schedule->event->days() as $day)
                     'options' =>
                     [
                         '' => 'Select a duration',
-                        '3:00' => 'Regular Shift (3 hours)',
-                        '6:00' => 'Shift Lead (6 hours)',
+                        '03:00' => 'Regular Shift (3 hours)',
+                        '06:00' => 'Shift Lead (6 hours)',
                         'custom' => 'Other'
                     ],
                     'value' => $schedule->duration


### PR DESCRIPTION
ref https://github.com/playasoft/volunteers/issues/132 , https://github.com/playasoft/volunteers/pull/131 , https://github.com/playasoft/volunteers/issues/68
so really the JS validation messing up was only a symptom of a bigger problem, the formatting on the backend. basically it didn't format hours properly if they were less than 10. so i added a couple ternary operators to check for that, and I left duration alone as it didn't have an affect on the app. a quick grep showed that only the schedule and schedule controller was using it.