### PR TITLE
Feature/shift email confirmation

### DIFF
--- a/laravel/app/Http/Controllers/SlotController.php
+++ b/laravel/app/Http/Controllers/SlotController.php
@@ -198,7 +198,7 @@ class SlotController extends Controller
 
             $slot->user_id=$user->data->user_id;
             $slot->save();
-            event(new SlotChanged($slot, ['status' => 'taken', 'adminAssigned' => true, 'name' => $user->name, 'email' => $user->email]));
+            event(new SlotChanged($slot, ['status' => 'taken', 'admin_assigned' => true, 'name' => $user->name, 'email' => $user->email]));
             $request->session()->flash('success', 'You added '.$username.' to this shift');
         }
         return redirect('/event/'.$slot->event->id);

--- a/laravel/app/Http/Controllers/SlotController.php
+++ b/laravel/app/Http/Controllers/SlotController.php
@@ -103,7 +103,7 @@ class SlotController extends Controller
             $slot->user_id = Auth::user()->id;
             $slot->save();
 
-            event(new SlotChanged($slot, ['status' => 'taken', 'name' => Auth::user()->name]));
+            event(new SlotChanged($slot, ['status' => 'taken', 'name' => Auth::user()->name, 'email' => Auth::user()->email]));
             $request->session()->flash('success', 'You signed up for a volunteer shift.');
 
             // If a password was used
@@ -198,7 +198,7 @@ class SlotController extends Controller
 
             $slot->user_id=$user->data->user_id;
             $slot->save();
-            event(new SlotChanged($slot, ['status' => 'taken']));
+            event(new SlotChanged($slot, ['status' => 'taken', 'adminAssigned' => true, 'name' => $user->name, 'email' => $user->email]));
             $request->session()->flash('success', 'You added '.$username.' to this shift');
         }
         return redirect('/event/'.$slot->event->id);

--- a/laravel/app/Listeners/SendUserShiftConfirmation.php
+++ b/laravel/app/Listeners/SendUserShiftConfirmation.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Listeners;
+
+use Mail;
+use App\Events\SlotChanged;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendUserShiftConfirmation
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Send a user welcome email
+     *
+     * @param  SlotChanged  $event
+     * @return void
+     */
+    public function handle(SlotChanged $event)
+    {
+        if (isset($event->change['status'])) {
+            if ($event->change['status'] === 'taken') {
+                $slot = $event->slot;
+                $name = $event->change['name'];
+                $email = $event->change['email'];
+                $adminAssigned = (isset($event->change['adminAssigned'])) ? $event->change['adminAssigned'] : false;
+                Mail::send('emails/user-shift-confirmation', compact('slot','adminAssigned'), function ($message) use ($slot, $name, $email) {
+                    $message->to($email, $name)->subject('Confimation Email - ' . $slot->schedule->shift->name . ' shift!');
+                });
+            }
+        }
+    }
+}

--- a/laravel/app/Listeners/SendUserShiftConfirmation.php
+++ b/laravel/app/Listeners/SendUserShiftConfirmation.php
@@ -20,7 +20,7 @@ class SendUserShiftConfirmation
     }
 
     /**
-     * Send a user welcome email
+     * Send a user a confimation email for taken/assigned shift
      *
      * @param  SlotChanged  $event
      * @return void

--- a/laravel/app/Listeners/SendUserShiftConfirmation.php
+++ b/laravel/app/Listeners/SendUserShiftConfirmation.php
@@ -27,16 +27,29 @@ class SendUserShiftConfirmation
      */
     public function handle(SlotChanged $event)
     {
-        if (isset($event->change['status'])) {
-            if ($event->change['status'] === 'taken') {
-                $slot = $event->slot;
-                $name = $event->change['name'];
-                $email = $event->change['email'];
-                $adminAssigned = (isset($event->change['adminAssigned'])) ? $event->change['adminAssigned'] : false;
-                Mail::send('emails/user-shift-confirmation', compact('slot','adminAssigned'), function ($message) use ($slot, $name, $email) {
-                    $message->to($email, $name)->subject('Confimation Email - ' . $slot->schedule->shift->name . ' shift!');
-                });
+        if ($event->change['status'] === 'taken')
+        {
+            $slot = $event->slot;
+            $user_email = $event->change['email'];
+            $user_name = $event->change['name'];
+            $event_name = $event->slot->schedule->shift->event->name;
+            $shift_name = $event->slot->schedule->shift->name;
+            $start_date = $event->slot->start_date;
+            $start_time = $event->slot->start_date;
+            $end_time = $event->slot->end_time;
+
+            $admin_assigned = false;
+            if (isset($event->change['admin_assigned']))
+            {
+                $admin_assigned = $event->change['admin_assigned'];
             }
+
+            $event_data = compact('slot', 'user_email', 'user_name', 'event_name', 'shift_name', 'start_date', 'start_time', 'end_time', 'admin_assigned');
+
+            Mail::send('emails/user-shift-confirmation', $event_data, function ($message) use ($user_email, $user_name, $shift_name)
+            {
+                $message->to($user_email, $user_name)->subject('Confirmation Email - ' . $shift_name . ' shift!');
+            });
         }
     }
 }

--- a/laravel/app/Providers/EventServiceProvider.php
+++ b/laravel/app/Providers/EventServiceProvider.php
@@ -34,6 +34,11 @@ class EventServiceProvider extends ServiceProvider
         [
             'App\Listeners\SendUserMessage',
         ],
+
+        'App\Events\SlotChanged' =>
+        [
+            'App\Listeners\SendUserShiftConfirmation',
+        ],
     ];
 
     /**

--- a/laravel/resources/views/emails/user-shift-confirmation.blade.php
+++ b/laravel/resources/views/emails/user-shift-confirmation.blade.php
@@ -19,7 +19,7 @@
 
 <p>
     If you did <b>NOT</b> sign-up for this shift or would like to <b>CANCEL</b> this
-    shift, <a href="{{ env('SITE_URL').'/slot'.$slot->id.'/view' }}">click here</a>.
+    shift, <a href="{{ env('SITE_URL').'/slot/'.$slot->id.'/view' }}">click here</a>.
 </p>
 
 <p>

--- a/laravel/resources/views/emails/user-shift-confirmation.blade.php
+++ b/laravel/resources/views/emails/user-shift-confirmation.blade.php
@@ -1,20 +1,20 @@
-<h1>You're signed up for the {{ $slot->schedule->shift->name }} shift!</h1>
+<h1>You're signed up for the {{ $shift_name }} shift!</h1>
 
-@if ($adminAssigned)
+@if ($admin_assigned)
 <p>
-   This is a confirmation email for the {{ $slot->schedule->shift->name }} shift
-   that you were recently assigned to for the {{ $slot->schedule->shift->event->name }} event.
+   This is a confirmation email for the {{ $shift_name }} shift
+   that you were recently assigned to for the {{ $event_name }} event.
 </p>
 @else
 <p>
-   This is a confirmation email for the {{ $slot->schedule->shift->name }} shift
-   you recently picked up for the {{ $slot->schedule->shift->event->name }} event.
+   This is a confirmation email for the {{ $shift_name }} shift
+   you recently picked up for the {{ $shift_name }} event.
 </p>
 @endif
 
 <p>
-    This shift takes place on {{ $slot->start_date }} between the times of
-    {{ $slot->start_time }} and {{ $slot->end_time }}.
+    This shift takes place on {{ $start_date}} between the times of
+    {{ $start_time }} and {{ $end_time }}.
 </p>
 
 <p>
@@ -23,5 +23,5 @@
 </p>
 
 <p>
-Otherwise, we look forward to seeing you there!
+    Otherwise, we look forward to seeing you there!
 </p>

--- a/laravel/resources/views/emails/user-shift-confirmation.blade.php
+++ b/laravel/resources/views/emails/user-shift-confirmation.blade.php
@@ -1,0 +1,27 @@
+<h1>You're signed up for the {{ $slot->schedule->shift->name }} shift!</h1>
+
+@if ($adminAssigned)
+<p>
+   This is a confirmation email for the {{ $slot->schedule->shift->name }} shift
+   that you were recently assigned to for the {{ $slot->schedule->shift->event->name }} event.
+</p>
+@else
+<p>
+   This is a confirmation email for the {{ $slot->schedule->shift->name }} shift
+   you recently picked up for the {{ $slot->schedule->shift->event->name }} event.
+</p>
+@endif
+
+<p>
+    This shift takes place on {{ $slot->start_date }} between the times of
+    {{ $slot->start_time }} and {{ $slot->end_time }}.
+</p>
+
+<p>
+    If you did <b>NOT</b> sign-up for this shift or would like to <b>CANCEL</b> this
+    shift, <a href="{{ env('SITE_URL').'/slot'.$slot->id.'/view' }}">click here</a>.
+</p>
+
+<p>
+Otherwise, we look forward to seeing you there!
+</p>


### PR DESCRIPTION
Fixes #82 

Confirmation emails for taken/assigned shift are now available to volunteers.

The email slightly varies whether the shift was taken or assigned to minimize volunteer confusion.
I also included a link in the email to point them to the slot if they wish to cancel their scheduling.

I'd like to go ahead and separate the issue of throwing the confirmation emails into a queue...

> We might want to queue / batch these notifications so only a single email is sent per user per day? Similar to the way notifications are handled in the art grants project ( https://github.com/playasoft/weightlifter )

and make that into an issue where we can start placing just about all emails in a queue that can be sent at differing intervals.

Some things for consideration...

* Should a cancelation link be included if they were assigned by an admin/event-admin?
* Should the user be made aware of who assigned them if they were assigned the shift?