### PR TITLE
[fix] cascading soft deletes now has a trait

### DIFF
--- a/laravel/app/CascadingSoftDeletes.php
+++ b/laravel/app/CascadingSoftDeletes.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait CascadingSoftDeletes
+{
+    protected static function bootCascadingSoftDeletes()
+    {
+        static::deleting(function ($model) {
+            $relationships = $model->getNonNullRelationships();
+            foreach($relationships as $relationship)
+            {
+                if($relationship instanceof Model)
+                {
+                    $relationship->delete();
+                }
+                else
+                {
+                    foreach($relationship as $member)
+                    {
+                        $member->delete();
+                    }
+                }
+            }
+        });
+    }
+
+    protected function getNonNullRelationships()
+    {
+        $relationships = [];
+        $relationship_names = $this->cascading_deletes ?? [];
+        foreach($relationship_names as $relationship_name)
+        {
+            if($this->{$relationship_name} === null)
+            {
+                continue;
+            }
+            $relationships[] = $this->{$relationship_name};
+        }
+
+        return $relationships;
+    }
+}

--- a/laravel/app/Models/Department.php
+++ b/laravel/app/Models/Department.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use App\CascadingSoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Department extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, CascadingSoftDeletes;
+
+    protected $cascading_deletes = ['shifts', 'schedule'];
 
     protected $fillable = ['name', 'description'];
 

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -6,10 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Carbon\Carbon;
 use App\Models\Schedule;
+use App\CascadingSoftDeletes;
 
 class Event extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, CascadingSoftDeletes;
+
+    protected $cascading_deletes = ['departments', 'shifts'];
 
     protected $fillable = ['name', 'description', 'start_date', 'end_date', 'featured'];
 
@@ -119,7 +122,7 @@ class Event extends Model
                 // remove duplicate dates
                 $shift_dates = array_unique( $merged_dates );
             }
-            
+
             // $date keeps track of the current date as we loop towards the end
             $date = $start_date;
 

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -2,12 +2,16 @@
 
 namespace App\Models;
 
+use App\CascadingSoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Schedule extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, CascadingSoftDeletes;
+
+    protected $cascading_deletes = ['slots'];
+
     protected $table = 'schedule';
     protected $fillable = ['department_id', 'shift_id', 'start_date', 'end_date', 'dates', 'start_time', 'end_time', 'duration', 'volunteers', 'password'];
 

--- a/laravel/tests/Feature/CascadingSoftDeletesTest.php
+++ b/laravel/tests/Feature/CascadingSoftDeletesTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Slot;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CascadingSoftDeletesTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function event_soft_delete_cascades()
+    {
+        // Given
+        $slot = factory(Slot::class)->create();
+        $event = $slot->schedule->department->event;
+        $department = $slot->schedule->department;
+        $shift = $slot->schedule->shift;
+        $schedule = $slot->schedule;
+
+        // dd($department);
+
+        // When
+        $slot->event->delete();
+
+        // Then
+        //soft deleted
+        $this->assertDatabaseHas('events', [
+            'id' => $event->id,
+        ]);
+        $this->assertDatabaseMissing('events', [
+            'id' => $event->id,
+            'deleted_at' => null,
+        ]);
+
+        //soft deleted
+        $this->assertDatabaseHas('departments', [
+            'id' => $department->id,
+        ]);
+        $this->assertDatabaseMissing('departments', [
+            'id' => $department->id,
+            'deleted_at' => null,
+        ]);
+
+        //deleted
+        $this->assertDatabaseMissing('shifts', [
+            'id' => $shift->id,
+        ]);
+
+        //deleted, since the shift is deleted
+        $this->assertDatabaseMissing('schedule', [
+            'id' => $schedule->id,
+        ]);
+
+        //deleted
+        $this->assertDatabaseMissing('slots', [
+            'id' => $slot->id,
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes #62

+ CascadingSoftDelete trait to allow recurring soft deletes for each 
Model that has soft delete
Note: all relationships must be included so that the soft delete can 
activate delete on both hard and soft deletes for children

~ added trait to soft delete classes: department, event, and schedule

Except for a bit of cleanup and commenting, this should solve the problem of soft deletes not hitting the SQL trigger for ```onDelete('cascade')```, since it only updates the ```deleted_at``` field instead. It now triggers delete for all relationships associated with it.