### PR TITLE
Feature/publish events

### DIFF
--- a/laravel/app/Cascade.php
+++ b/laravel/app/Cascade.php
@@ -41,7 +41,7 @@ trait Cascade
             $updated_fields = $model->getDirty();
             foreach($update_fields as $update_field => $update_relationships)
             {
-                if(!in_array($update_field, $updated_fields))
+                if(!in_array($update_field, array_keys($updated_fields)))
                 {
                     continue;
                 }
@@ -74,7 +74,7 @@ trait Cascade
                 {
                     throw new Exception($relationship.' relation not found!');
                 }
-                
+
                 static::cascadeRelationship($model->{$delete_relationship}, function(Model $model) {
                     $model->delete();
                 });

--- a/laravel/app/Cascade.php
+++ b/laravel/app/Cascade.php
@@ -45,6 +45,10 @@ trait Cascade
                 {
                     continue;
                 }
+                if($update_relationships === 'all')
+                {
+                    $update_relationships = $relationships;
+                }
                 foreach($update_relationships as $update_relationship)
                 {
                     if(!in_array($update_relationship, $relationships))

--- a/laravel/app/Cascade.php
+++ b/laravel/app/Cascade.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App;
+
+use ReflectionClass;
+use ReflectionMethod;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+
+trait Cascade
+{
+    /**
+     * Structure:
+     *
+     * @return mixed
+     */
+    protected abstract static function cascadeUpdateRelationshipFields();
+
+    /**
+     * Structure:
+     *
+     * @return mixed
+     */
+    protected abstract static function cascadeDeleteRelationships();
+
+    /**
+     *
+     */
+    protected abstract static function relationships();
+
+    /**
+     * [bootCascade description]
+     * @return [type] [description]
+     */
+    public static function bootCascade()
+    {
+        static::updating(function(Model $model) {
+            $relationships = $model->relationships();
+            $update_fields = $model->cascadeUpdateRelationshipFields();
+            $updated_fields = $model->getDirty();
+            foreach($update_fields as $update_field => $update_relationships)
+            {
+                if(!in_array($update_field, $updated_fields))
+                {
+                    continue;
+                }
+                foreach($update_relationships as $update_relationship)
+                {
+                    if(!in_array($update_relationship, $relationships))
+                    {
+                        throw new Exception($relationship.' relation not found!');
+                    }
+
+                    $dirty_field = $updated_fields[$update_field];
+                    static::cascadeRelationship($model->{$update_relationship}, function(Model $model) use ($update_field, $dirty_field) {
+                        $model->{$update_field} = $dirty_field;
+                        $model->save();
+                    });
+                }
+            }
+        });
+
+        static::deleting(function(Model $model) {
+            $relationships = $model->relationships();
+            $delete_relationships = $model->cascadeDeleteRelationships();
+            if($delete_relationships === 'all')
+            {
+                $delete_relationships = $relationships;
+            }
+            foreach($delete_relationships as $delete_relationship)
+            {
+                if(!in_array($delete_relationship, $relationships))
+                {
+                    throw new Exception($relationship.' relation not found!');
+                }
+                
+                static::cascadeRelationship($model->{$delete_relationship}, function(Model $model) {
+                    $model->delete();
+                });
+            }
+        });
+    }
+
+    /**
+     * [cascadeRelationship description]
+     * @param  [type] $relationship [description]
+     * @param  [type] $cascadeFunc  [description]
+     * @return [type]               [description]
+     */
+    protected static function cascadeRelationship($relation, $cascadeFunc)
+    {
+        if($relation === null)
+        {
+            return;
+        }
+        if($relation instanceof Model)
+        {
+            $cascadeFunc($relation);
+        }
+        else
+        {
+            foreach($relation as $related_model)
+            {
+                $cascadeFunc($related_model);
+            }
+        }
+    }
+
+    /**
+     * [relationships description]
+     * @param  Model  $model [description]
+     * @return [type]        [description]
+     */
+    // public static function relationships(Model $model)
+    // {
+    //     $relationships = [];
+    //
+    //     $reflector = new ReflectionClass($model);
+    //     $methods = $reflector->getMethods(ReflectionMethod::IS_PUBLIC);
+    //     foreach($methods as $method)
+    //     {
+    //         // check if method isn't instantiated in child class
+    //         if($method->class != get_class($model))
+    //         {
+    //             continue;
+    //         }
+    //         //check if method has no parameters
+    //         if(!empty($method->getParameters()))
+    //         {
+    //             continue;
+    //         }
+    //         //check if method is this method
+    //         if($method->getName() == __FUNCTION__)
+    //         {
+    //             continue;
+    //         }
+    //
+    //         try
+    //         {
+    //             $return = $model->{$method->getShortName()}();
+    //
+    //             if($return instanceof Relation)
+    //             {
+    //                 $relationships[] = $method->getShortName();
+    //             }
+    //         }
+    //         catch(ErrorException $e)
+    //         {
+    //         }
+    //     }
+    //
+    //     return $relationships;
+    // }
+}

--- a/laravel/app/Http/Controllers/DepartmentController.php
+++ b/laravel/app/Http/Controllers/DepartmentController.php
@@ -18,6 +18,7 @@ class DepartmentController extends Controller
     {
         $this->middleware('auth');
         $this->middleware('bindings');
+        $this->middleware('published:department');
     }
 
     // Display list of departments in an event
@@ -44,7 +45,7 @@ class DepartmentController extends Controller
         $department->event_id = $input['event_id'];
         $department->save();
         $department->update($input);
-        
+
         event(new EventChanged($department->event, ['type' => 'department', 'status' => 'created']));
 
         $request->session()->flash('success', 'Your department has been created.');

--- a/laravel/app/Http/Controllers/EventController.php
+++ b/laravel/app/Http/Controllers/EventController.php
@@ -23,6 +23,7 @@ class EventController extends Controller
     {
         $this->middleware('auth');
         $this->middleware('bindings');
+        $this->middleware('published:event');
     }
 
     // Private function to manage file uploads

--- a/laravel/app/Http/Controllers/ScheduleController.php
+++ b/laravel/app/Http/Controllers/ScheduleController.php
@@ -22,6 +22,7 @@ class ScheduleController extends Controller
     {
         $this->middleware('auth');
         $this->middleware('bindings');
+        $this->middleware('published:schedule');
     }
 
     // Helper function to convert form input into database-friendly information
@@ -136,7 +137,7 @@ class ScheduleController extends Controller
         $regenerateSlots = false;
         $volunteersChanged = false;
         $warnUser = false;
-        
+
         if($schedule->start_date != $input['start_date'] ||
             $schedule->end_date != $input['end_date'] ||
             $schedule->start_time != $input['start_time'] ||
@@ -187,7 +188,7 @@ class ScheduleController extends Controller
         }
 
         event(new EventChanged($schedule->event, ['type' => 'schedule', 'status' => 'edited']));
-        
+
         $request->session()->flash('success', 'Schedule schedule has been updated.');
         return redirect('/event/' . $schedule->event->id);
     }

--- a/laravel/app/Http/Controllers/ShiftController.php
+++ b/laravel/app/Http/Controllers/ShiftController.php
@@ -21,6 +21,7 @@ class ShiftController extends Controller
     {
         $this->middleware('auth');
         $this->middleware('bindings');
+        $this->middleware('published:shift');
     }
 
     // Display list of shifts in an event

--- a/laravel/app/Http/Controllers/SlotController.php
+++ b/laravel/app/Http/Controllers/SlotController.php
@@ -23,6 +23,7 @@ class SlotController extends Controller
     {
         $this->middleware('auth');
         $this->middleware('bindings');
+        $this->middleware('published:slot');
     }
 
     // Helper function to determine if an event has passed

--- a/laravel/app/Http/Kernel.php
+++ b/laravel/app/Http/Kernel.php
@@ -51,5 +51,6 @@ class Kernel extends HttpKernel
         'admin' => \App\Http\Middleware\IsAdmin::class,
         'lead' => \App\Http\Middleware\IsLead::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        'published' => \App\Http\Middleware\CheckPublished::class,
     ];
 }

--- a/laravel/app/Http/Middleware/CheckPublished.php
+++ b/laravel/app/Http/Middleware/CheckPublished.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\Guard;
+use App\Models\Slot;
+
+class CheckPublished
+{
+    /**
+     * The Guard implementation.
+     *
+     * @var Guard
+     */
+    protected $auth;
+
+    /**
+     * Create a new filter instance.
+     *
+     * @param  Guard  $auth
+     * @return void
+     */
+    public function __construct(Guard $auth)
+    {
+        $this->auth = $auth;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $model)
+    {
+        $is_published = ($request->{$model}->published_at !== null);
+        $is_admin= $this->auth->user()->hasRole('admin');
+        $is_department_lead = $this->auth->user()->hasRole('department-lead');
+
+        if(!$is_published && !$is_admin && !$is_department_lead)
+        {
+            return response('Unauthorized.', 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/laravel/app/Models/Department.php
+++ b/laravel/app/Models/Department.php
@@ -2,12 +2,49 @@
 
 namespace App\Models;
 
+use App\Cascade;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Department extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, Cascade;
+
+    /**
+     * Structure:
+     *
+     * @return mixed
+     */
+    protected static function cascadeUpdateRelationshipFields()
+    {
+        return [
+            'published_at' => [
+                'shifts',
+                'schedule',
+            ],
+        ];
+    }
+
+    /**
+     * Structure:
+     *
+     * @return mixed
+     */
+    protected static function cascadeDeleteRelationships()
+    {
+        return 'all';
+    }
+
+    /**
+     *
+     */
+    protected static function relationships()
+    {
+        return [
+            'shifts',
+            'schedule',
+        ];
+    }
 
     protected $fillable = ['name', 'description'];
 

--- a/laravel/app/Models/Department.php
+++ b/laravel/app/Models/Department.php
@@ -18,10 +18,7 @@ class Department extends Model
     protected static function cascadeUpdateRelationshipFields()
     {
         return [
-            'published_at' => [
-                'shifts',
-                'schedule',
-            ],
+            'published_at' => 'all',
         ];
     }
 

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -21,7 +21,12 @@ class Event extends Model
      */
     protected static function cascadeUpdateRelationshipFields()
     {
-        return [];
+        return [
+            'published_at' => [
+                'departments',
+                'shifts',    
+            ],
+        ];
     }
 
     /**

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Cascade;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Carbon\Carbon;
@@ -9,9 +10,37 @@ use App\Models\Schedule;
 
 class Event extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, Cascade;
 
     protected $fillable = ['name', 'description', 'start_date', 'end_date', 'featured'];
+
+    /**
+     * Structure:
+     *
+     * @return mixed
+     */
+    protected static function cascadeUpdateRelationshipFields()
+    {
+        return [];
+    }
+
+    /**
+     * Structure:
+     *
+     * @return mixed
+     */
+    protected static function cascadeDeleteRelationships()
+    {
+        return 'all';
+    }
+
+    protected static function relationships()
+    {
+        return [
+            'departments',
+            'shifts',
+        ];
+    }
 
     // Helper functions to select events by date
     public static function future($preferFeatured = false)
@@ -119,7 +148,7 @@ class Event extends Model
                 // remove duplicate dates
                 $shift_dates = array_unique( $merged_dates );
             }
-            
+
             // $date keeps track of the current date as we loop towards the end
             $date = $start_date;
 

--- a/laravel/app/Models/Event.php
+++ b/laravel/app/Models/Event.php
@@ -22,10 +22,7 @@ class Event extends Model
     protected static function cascadeUpdateRelationshipFields()
     {
         return [
-            'published_at' => [
-                'departments',
-                'shifts',    
-            ],
+            'published_at' => 'all',
         ];
     }
 

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -2,14 +2,52 @@
 
 namespace App\Models;
 
+use App\Cascade;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Schedule extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, Cascade;
+
     protected $table = 'schedule';
     protected $fillable = ['department_id', 'shift_id', 'start_date', 'end_date', 'dates', 'start_time', 'end_time', 'duration', 'volunteers', 'password'];
+
+    /**
+     * Structure:
+     *
+     * @return mixed
+     */
+    protected static function cascadeUpdateRelationshipFields()
+    {
+        return [
+            'published_at' => [
+                'slots',
+            ],
+        ];
+    }
+
+    /**
+     * Structure:
+     *
+     * @return mixed
+     */
+    protected static function cascadeDeleteRelationships()
+    {
+        return [
+            'slots',
+        ];
+    }
+
+    /**
+     *
+     */
+    protected static function relationships()
+    {
+        return [
+            'slots',
+        ];
+    }
 
     // Schedules belong to a shift
     public function shift()

--- a/laravel/app/Models/Schedule.php
+++ b/laravel/app/Models/Schedule.php
@@ -21,9 +21,7 @@ class Schedule extends Model
     protected static function cascadeUpdateRelationshipFields()
     {
         return [
-            'published_at' => [
-                'slots',
-            ],
+            'published_at' => 'all',
         ];
     }
 
@@ -34,9 +32,7 @@ class Schedule extends Model
      */
     protected static function cascadeDeleteRelationships()
     {
-        return [
-            'slots',
-        ];
+        return 'all';
     }
 
     /**

--- a/laravel/database/factories/UserFactory.php
+++ b/laravel/database/factories/UserFactory.php
@@ -15,13 +15,6 @@ $factory->define(User::class, function (Faker $faker, array $data)
     ];
 });
 
-$factory->state(User::class, 'admin', function (Faker $faker)
-{
-    return
-    [
-    ];
-});
-
 $factory->afterCreatingState(User::class, 'admin', function (User $user, Faker $faker)
 {
     //find the admin role
@@ -31,6 +24,25 @@ $factory->afterCreatingState(User::class, 'admin', function (User $user, Faker $
     {
         $admin_role = factory(Role::class)->create([
             'name' => 'admin',
+        ]);
+    }
+
+    $user->roles()->save(factory(UserRole::class)->make([
+        'role_id' => $admin_role->id,
+        'user_id' => $user->id,
+    ]));
+});
+
+$factory->afterCreatingState(User::class, 'department-lead', function (User $user, Faker $faker)
+{
+    //find the admin role
+    $role_name = 'department-lead';
+    $admin_role = Role::where('name', $role_name)->first();
+    //if there is no admin role, create it
+    if (!$admin_role)
+    {
+        $admin_role = factory(Role::class)->create([
+            'name' => $role_name,
         ]);
     }
 

--- a/laravel/database/migrations/2019_07_14_234901_add_publish_at_to_events.php
+++ b/laravel/database/migrations/2019_07_14_234901_add_publish_at_to_events.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPublishAtToEvents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->timestamp('published_at')->nullable();
+        });
+        Schema::table('departments', function (Blueprint $table) {
+            $table->timestamp('published_at')->nullable();
+        });
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->timestamp('published_at')->nullable();
+        });
+        Schema::table('schedule', function (Blueprint $table) {
+            $table->timestamp('published_at')->nullable();
+        });
+        Schema::table('slots', function (Blueprint $table) {
+            $table->timestamp('published_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+        Schema::table('departments', function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+        Schema::table('schedule', function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+        Schema::table('slots', function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+    }
+}

--- a/laravel/tests/Feature/CascadeTest.php
+++ b/laravel/tests/Feature/CascadeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Slot;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CascadeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function cascade_delete()
+    {
+        // Given
+        $slot = factory(Slot::class)->create(); //bottom child
+        $schedule = $slot->schedule;
+        $shift = $slot->schedule->shift;
+        $department = $slot->schedule->department;
+        $event = $slot->schedule->department->event; //top parent
+
+        // When
+        $event->delete();
+
+        // Then
+        $this->assertSoftDeleted('events', [
+            'id' => $event->id,
+        ]);
+
+        $this->assertSoftDeleted('departments', [
+            'id' => $department->id,
+        ]);
+
+        $this->assertDatabaseMissing('shifts', [
+            'id' => $shift->id,
+        ]);
+
+        $this->assertDatabaseMissing('schedule', [
+            'id' => $schedule->id,
+        ]);
+
+
+        $this->assertDatabaseMissing('slots', [
+            'id' => $slot->id,
+        ]);
+    }
+}

--- a/laravel/tests/Feature/CheckPublishedTest.php
+++ b/laravel/tests/Feature/CheckPublishedTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Slot;
+use App\Models\UserData;
+use App\Models\Role;
+use App\Models\UserRole;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CheckPublishedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function can_view_unpublished_slot_as_department_lead()
+    {
+        // Given
+        $slot = factory(Slot::class)->create();
+        $user = factory(UserData::class)->states('department-lead')->create()->user;
+
+        $this->actingAs($user);
+
+        // When
+        $response = $this->get("/slot/$slot->id/view");
+
+        // Then
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     */
+    public function cannot_view_unpublished_slot_as_non_department_lead()
+    {
+        // Given
+        $slot = factory(Slot::class)->create();
+        $user = factory(UserData::class)->create()->user;
+
+        $this->actingAs($user);
+
+        // When
+        $response = $this->get("/slot/$slot->id/view");
+
+        // Then
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
Fixes #103 

This is a slight overkill to what was proposed for allowing events to be published.

It instead places a ```published_at``` field for slots, shifts, schedules, departments, and events.

It also includes a new ```Cascade``` trait similar to the one developed in #171.

This one tracks both updates to fields and soft deletes of rows so that they can be cascaded.

It needs some major cleanups with how it handles deletion. The Model hooks are a handy first step, but the way they're implemented introduces a lot of coupling which just makes everything look god awful.

There may be ways to avoid this by rewriting the ```Cascade``` trait to look at BelongsTo relations. This way requires a bit of knowledge of what type of model the relation points to, but if it can be done, then we have a much more cleanly written trait that acts similarly to how SQL cascades.