### PR TITLE
Add email delivery error handling

### DIFF
--- a/laravel/app/Listeners/SendAdminFileUploaded.php
+++ b/laravel/app/Listeners/SendAdminFileUploaded.php
@@ -34,9 +34,16 @@ class SendAdminFileUploaded
         // TODO: Options to choose which admins to notify
         $admin = User::where('id', 1)->first();
 
-        Mail::send('emails/admin-file-uploaded', compact('file'), function ($message) use ($admin)
+        try
         {
-            $message->to($admin->email, $admin->name)->subject('New file uploaded!');
-        });
+            Mail::send('emails/admin-file-uploaded', compact('file'), function ($message) use ($admin)
+            {
+                $message->to($admin->email, $admin->name)->subject('New file uploaded!');
+            });
+        }
+        catch (\Exception $exception)
+        {
+            app('request')->session()->flash('warning', "Unable to send email notification, SMTP error. Please notify the administrator of this volunteer database.");
+        }
     }
 }

--- a/laravel/app/Listeners/SendAdminRemovedShift.php
+++ b/laravel/app/Listeners/SendAdminRemovedShift.php
@@ -33,20 +33,25 @@ class SendAdminRemovedShift
             if($event->change['status'] === 'released' && $event->change['admin_released'] === true)
             {
                 $schedule = $event->slot->schedule;
+                $slot = $event->slot;
+                $user_email = $event->slot->user->email;
+                $user_name = $event->slot->user->name;
+                $shift_name = $event->slot->schedule->shift->name;
+                $shift_date = Carbon::createFromFormat('Y-m-d', $schedule->start_date)->toFormattedDateString();
+                $shift_time = $schedule->start_time;
 
-              $slot = $event->slot;
-              $user_email = $event->slot->user->email;
-              $user_name = $event->slot->user->name;
-              $shift_name = $event->slot->schedule->shift->name;
-              $shift_date = Carbon::createFromFormat('Y-m-d', $schedule->start_date)->toFormattedDateString();
-              $shift_time = $schedule->start_time;
-
-              $event_data = compact('slot', 'user_email', 'user_name', 'shift_name', 'shift_date', 'shift_time');
-
-              Mail::send('emails/admin-removed-shift', $event_data, function ($message) use ($user_email, $user_name)
-              {
-                  $message->to($user_email, $user_name)->subject('Shift reschedule required!');
-              });
+                $event_data = compact('slot', 'user_email', 'user_name', 'shift_name', 'shift_date', 'shift_time');
+                try
+                {
+                    Mail::send('emails/admin-removed-shift', $event_data, function ($message) use ($user_email, $user_name)
+                    {
+                        $message->to($user_email, $user_name)->subject('Shift reschedule required!');
+                    });
+                }
+                catch (\Exception $exception)
+                {
+                    app('request')->session()->flash('warning', "Unable to send email notification, SMTP error. Please notify the administrator of this volunteer database.");
+                }
             }
         }
     }

--- a/laravel/app/Listeners/SendAdminWelcome.php
+++ b/laravel/app/Listeners/SendAdminWelcome.php
@@ -34,9 +34,16 @@ class SendAdminWelcome
         // TODO: Options to choose which admins to notify
         $admin = User::where('id', 1)->first();
 
-        Mail::send('emails/admin-welcome', compact('user'), function ($message) use ($admin)
+        try
         {
-            $message->to($admin->email, $admin->name)->subject('New user registered!');
-        });
+            Mail::send('emails/admin-welcome', compact('user'), function ($message) use ($admin)
+            {
+                $message->to($admin->email, $admin->name)->subject('New user registered!');
+            });
+        }
+        catch (\Exception $exception)
+        {
+            app('request')->session()->flash('warning', "Unable to send email confirmation, SMTP error. Please notify the administrator of this volunteer database.");
+        }
     }
 }

--- a/laravel/app/Listeners/SendUserFileChanged.php
+++ b/laravel/app/Listeners/SendUserFileChanged.php
@@ -29,20 +29,26 @@ class SendUserFileChanged
     {
         $file = $event->file;
         $user = $event->file->user;
-
-        if($file->status == 'approved')
+        try
         {
-            Mail::send('emails/user-file-approved', compact('file', 'user'), function ($message) use ($user)
+            if($file->status == 'approved')
             {
-                $message->to($user->email, $user->name)->subject('Uploaded File Approved');
-            });
+                Mail::send('emails/user-file-approved', compact('file', 'user'), function ($message) use ($user)
+                {
+                    $message->to($user->email, $user->name)->subject('Uploaded File Approved');
+                });
+            }
+            elseif($file->status == 'denied')
+            {
+                Mail::send('emails/user-file-denied', compact('file', 'user'), function ($message) use ($user)
+                {
+                    $message->to($user->email, $user->name)->subject('Uploaded File Denied');
+                });
+            }
         }
-        elseif($file->status == 'denied')
+        catch (\Exception $exception)
         {
-            Mail::send('emails/user-file-denied', compact('file', 'user'), function ($message) use ($user)
-            {
-                $message->to($user->email, $user->name)->subject('Uploaded File Denied');
-            });
+            // Todo: Have a warning show up when the admin clicks save.
         }
     }
 }

--- a/laravel/app/Listeners/SendUserMessage.php
+++ b/laravel/app/Listeners/SendUserMessage.php
@@ -45,9 +45,16 @@ class SendUserMessage
     {
         $user = $event->user;
 
-        Mail::send('emails/forgot-password', compact('user'), function ($message) use ($user)
+        try
         {
-            $message->to($user->email, $user->name)->subject('Your Password Reset Code');
-        });
+            Mail::send('emails/forgot-password', compact('user'), function ($message) use ($user)
+            {
+                $message->to($user->email, $user->name)->subject('Your Password Reset Code');
+            });
+        }
+        catch (\Exception $exception)
+        {
+            app('request')->session()->flash('error', "Unable to send email, SMTP error. Please notify the administrator of this volunteer database.");
+        }
     }
 }

--- a/laravel/app/Listeners/SendUserShiftConfirmation.php
+++ b/laravel/app/Listeners/SendUserShiftConfirmation.php
@@ -46,10 +46,17 @@ class SendUserShiftConfirmation
 
             $event_data = compact('slot', 'user_email', 'user_name', 'event_name', 'shift_name', 'start_date', 'start_time', 'end_time', 'admin_assigned');
 
-            Mail::send('emails/user-shift-confirmation', $event_data, function ($message) use ($user_email, $user_name, $shift_name)
+            try
             {
-                $message->to($user_email, $user_name)->subject('Confirmation Email - ' . $shift_name . ' shift!');
-            });
+                Mail::send('emails/user-shift-confirmation', $event_data, function ($message) use ($user_email, $user_name, $shift_name)
+                {
+                    $message->to($user_email, $user_name)->subject('Confirmation Email - ' . $shift_name . ' shift!');
+                });
+            }
+            catch (\Exception $exception)
+            {
+                app('request')->session()->flash('warning', "Unable to send email confirmation, SMTP error. Please notify the administrator of this volunteer database.");
+            }
         }
     }
 }

--- a/laravel/app/Listeners/SendUserWelcome.php
+++ b/laravel/app/Listeners/SendUserWelcome.php
@@ -29,9 +29,16 @@ class SendUserWelcome
     {
         $user = $event->user;
         
-        Mail::send('emails/user-welcome', compact('user'), function ($message) use ($user)
+        try
         {
-            $message->to($user->email, $user->name)->subject('Welcome to the Volunteer Database!');
-        });
+            Mail::send('emails/user-welcome', compact('user'), function ($message) use ($user)
+            {
+                $message->to($user->email, $user->name)->subject('Welcome to the Volunteer Database!');
+            });
+        }
+        catch (\Exception $exception)
+        {
+            app('request')->session()->flash('warning', "Unable to send email confirmation, SMTP error. Please notify the administrator of this volunteer database.");
+        }
     }
 }

--- a/laravel/resources/views/app.blade.php
+++ b/laravel/resources/views/app.blade.php
@@ -39,6 +39,12 @@
                 </div>
             @endif
 
+            @if(Session::has('warning'))
+                <div class="general-alert alert alert-warning" role="alert">
+                    <b>Warning:</b> {{ Session::get('warning')}}
+                </div>
+            @endif
+
             @yield('content')
         </section>
 


### PR DESCRIPTION
#191

Wrapped the email sending in try-catches to gracefully display an error telling the user to contact an admin.
![image](https://user-images.githubusercontent.com/2872995/82830455-b4ea3480-9ead-11ea-8e41-3d0f3047f356.png)
I think creating a mail queue and using supervisor (optional?) to send unsent emails should be considered.

SendUserFileChanged.php has no error message because the page doesn't refresh/change when you click save, the error message would show up on a different page which might be confusing.