### PR TITLE
Add mail sender helper function

### DIFF
--- a/laravel/app/Helpers.php
+++ b/laravel/app/Helpers.php
@@ -34,4 +34,29 @@ class Helpers
 
         return $display_name;
     }
+
+    /**
+     * Mail sender Helper
+     * Sends an email and catches exceptions
+     * @param string    $view       The name of the view containing the email
+     * @param array     $data       Array of data to pass to the view
+     * @param Closure   $callback   Closure which recieves the email instance
+     */
+    public static function sendMail($view, $data, $callback)
+    {
+        try
+        {
+            \Mail::send($view, $data, $callback);
+        }
+        catch(\Exception $exception)
+        {
+            if (config('app.debug'))
+            {
+                throw $exception;
+            }
+            \Log::error($exception);
+
+            app('request')->session()->flash('warning', "Unable to send email, SMTP error. Please notify the administrator of this volunteer database.");
+        }
+    }
 }

--- a/laravel/app/Listeners/SendAdminFileUploaded.php
+++ b/laravel/app/Listeners/SendAdminFileUploaded.php
@@ -6,7 +6,7 @@ use App\Events\FileUploaded;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-use Mail;
+use App\Helpers;
 use App\Models\User;
 
 class SendAdminFileUploaded
@@ -34,16 +34,9 @@ class SendAdminFileUploaded
         // TODO: Options to choose which admins to notify
         $admin = User::where('id', 1)->first();
 
-        try
+        Helpers::sendMail('emails/admin-file-uploaded', compact('file'), function ($message) use ($admin)
         {
-            Mail::send('emails/admin-file-uploaded', compact('file'), function ($message) use ($admin)
-            {
-                $message->to($admin->email, $admin->name)->subject('New file uploaded!');
-            });
-        }
-        catch (\Exception $exception)
-        {
-            app('request')->session()->flash('warning', "Unable to send email notification, SMTP error. Please notify the administrator of this volunteer database.");
-        }
+            $message->to($admin->email, $admin->name)->subject('New file uploaded!');
+        });
     }
 }

--- a/laravel/app/Listeners/SendAdminRemovedShift.php
+++ b/laravel/app/Listeners/SendAdminRemovedShift.php
@@ -2,7 +2,7 @@
 
 namespace App\Listeners;
 
-use Mail;
+use App\Helpers;
 use App\Events\SlotChanged;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -41,17 +41,11 @@ class SendAdminRemovedShift
                 $shift_time = $schedule->start_time;
 
                 $event_data = compact('slot', 'user_email', 'user_name', 'shift_name', 'shift_date', 'shift_time');
-                try
+
+                Helpers::sendMail('emails/admin-removed-shift', $event_data, function ($message) use ($user_email, $user_name)
                 {
-                    Mail::send('emails/admin-removed-shift', $event_data, function ($message) use ($user_email, $user_name)
-                    {
-                        $message->to($user_email, $user_name)->subject('Shift reschedule required!');
-                    });
-                }
-                catch (\Exception $exception)
-                {
-                    app('request')->session()->flash('warning', "Unable to send email notification, SMTP error. Please notify the administrator of this volunteer database.");
-                }
+                    $message->to($user_email, $user_name)->subject('Shift reschedule required!');
+                });
             }
         }
     }

--- a/laravel/app/Listeners/SendAdminWelcome.php
+++ b/laravel/app/Listeners/SendAdminWelcome.php
@@ -2,7 +2,7 @@
 
 namespace App\Listeners;
 
-use Mail;
+use App\Helpers;
 use App\Events\UserRegistered;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -34,16 +34,9 @@ class SendAdminWelcome
         // TODO: Options to choose which admins to notify
         $admin = User::where('id', 1)->first();
 
-        try
+        Helpers::sendMail('emails/admin-welcome', compact('user'), function ($message) use ($admin)
         {
-            Mail::send('emails/admin-welcome', compact('user'), function ($message) use ($admin)
-            {
-                $message->to($admin->email, $admin->name)->subject('New user registered!');
-            });
-        }
-        catch (\Exception $exception)
-        {
-            app('request')->session()->flash('warning', "Unable to send email confirmation, SMTP error. Please notify the administrator of this volunteer database.");
-        }
+            $message->to($admin->email, $admin->name)->subject('New user registered!');
+        });
     }
 }

--- a/laravel/app/Listeners/SendUserFileChanged.php
+++ b/laravel/app/Listeners/SendUserFileChanged.php
@@ -48,10 +48,6 @@ class SendUserFileChanged
         }
         catch (\Exception $exception)
         {
-            if (config('app.debug'))
-            {
-                throw $exception;
-            }
             \Log::error($exception);
             // Todo: Have a warning show up when the admin clicks save.
         }

--- a/laravel/app/Listeners/SendUserFileChanged.php
+++ b/laravel/app/Listeners/SendUserFileChanged.php
@@ -48,6 +48,11 @@ class SendUserFileChanged
         }
         catch (\Exception $exception)
         {
+            if (config('app.debug'))
+            {
+                throw $exception;
+            }
+            \Log::error($exception);
             // Todo: Have a warning show up when the admin clicks save.
         }
     }

--- a/laravel/app/Listeners/SendUserMessage.php
+++ b/laravel/app/Listeners/SendUserMessage.php
@@ -5,7 +5,7 @@ namespace App\Listeners;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-use Mail;
+use App\Helpers;
 use App\Models\User;
 
 class SendUserMessage
@@ -45,16 +45,9 @@ class SendUserMessage
     {
         $user = $event->user;
 
-        try
+        Helpers::sendMail('emails/forgot-password', compact('user'), function ($message) use ($user)
         {
-            Mail::send('emails/forgot-password', compact('user'), function ($message) use ($user)
-            {
-                $message->to($user->email, $user->name)->subject('Your Password Reset Code');
-            });
-        }
-        catch (\Exception $exception)
-        {
-            app('request')->session()->flash('error', "Unable to send email, SMTP error. Please notify the administrator of this volunteer database.");
-        }
+            $message->to($user->email, $user->name)->subject('Your Password Reset Code');
+        });
     }
 }

--- a/laravel/app/Listeners/SendUserShiftConfirmation.php
+++ b/laravel/app/Listeners/SendUserShiftConfirmation.php
@@ -2,7 +2,7 @@
 
 namespace App\Listeners;
 
-use Mail;
+use App\Helpers;
 use App\Events\SlotChanged;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -46,17 +46,10 @@ class SendUserShiftConfirmation
 
             $event_data = compact('slot', 'user_email', 'user_name', 'event_name', 'shift_name', 'start_date', 'start_time', 'end_time', 'admin_assigned');
 
-            try
+            Helpers::sendMail('emails/user-shift-confirmation', $event_data, function ($message) use ($user_email, $user_name, $shift_name)
             {
-                Mail::send('emails/user-shift-confirmation', $event_data, function ($message) use ($user_email, $user_name, $shift_name)
-                {
-                    $message->to($user_email, $user_name)->subject('Confirmation Email - ' . $shift_name . ' shift!');
-                });
-            }
-            catch (\Exception $exception)
-            {
-                app('request')->session()->flash('warning', "Unable to send email confirmation, SMTP error. Please notify the administrator of this volunteer database.");
-            }
+                $message->to($user_email, $user_name)->subject('Confirmation Email - ' . $shift_name . ' shift!');
+            });
         }
     }
 }

--- a/laravel/app/Listeners/SendUserWelcome.php
+++ b/laravel/app/Listeners/SendUserWelcome.php
@@ -2,7 +2,7 @@
 
 namespace App\Listeners;
 
-use Mail;
+use App\Helpers;
 use App\Events\UserRegistered;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -29,16 +29,9 @@ class SendUserWelcome
     {
         $user = $event->user;
         
-        try
+        Helpers::sendMail('emails/user-welcome', compact('user'), function ($message) use ($user)
         {
-            Mail::send('emails/user-welcome', compact('user'), function ($message) use ($user)
-            {
-                $message->to($user->email, $user->name)->subject('Welcome to the Volunteer Database!');
-            });
-        }
-        catch (\Exception $exception)
-        {
-            app('request')->session()->flash('warning', "Unable to send email confirmation, SMTP error. Please notify the administrator of this volunteer database.");
-        }
+            $message->to($user->email, $user->name)->subject('Welcome to the Volunteer Database!');
+        });
     }
 }


### PR DESCRIPTION
Saved a lot of lines by wrapping Mail::send in a helper function which will flash a warning to the session if the mail fails, it'll also still throw the exception if in debug mode and log it regardless.

SendUserFileChanged.php isn't using it because the page is relatively dynamic and won't show the error until refresh/page change so it may be confusing.