### PR TITLE
fixed error checking when submitting no user, admin can remove themself

### DIFF
--- a/laravel/app/Http/Controllers/SlotController.php
+++ b/laravel/app/Http/Controllers/SlotController.php
@@ -182,8 +182,12 @@ class SlotController extends Controller
     }
 
     public function adminAssign(Request $request, Slot $slot)
-    {
-        $user = User::findorFail($request->get('user'));
+    {   
+        $user = User::find($request->get('user'));
+        if (empty($user)) {
+            $request->session()->flash('error', 'You didn\'t select a user to add.');
+            return redirect()->back();
+        }
 
         if(is_null($slot->user))
         {

--- a/laravel/package.json
+++ b/laravel/package.json
@@ -19,10 +19,11 @@
     "webpack-cli": "^4.0.0"
   },
   "dependencies": {
+    "@babel/preset-env": "^7.16.11",
     "bootstrap-sass": "^3.4.1",
     "ejs-loader": "^0.5.0",
     "estraverse": "^5.2.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "sass": "^1.27.0",
     "socket.io-client": "^2.3.1",
     "wetfish-basic": "^0.7.11"

--- a/laravel/resources/views/pages/slot/view.blade.php
+++ b/laravel/resources/views/pages/slot/view.blade.php
@@ -15,12 +15,17 @@ if(!empty($slot->user))
     {
         $self = true;
         $url = "/slot/{$slot->id}/release";
+        //if the admin is trying to release themselves from a slot
+        if(Auth::user()->hasRole('admin') || Auth::user()->hasRole('department-lead'))
+        {
+            $url = "/slot/{$slot->id}/adminRelease";
+        }
     }
     else
     {
         $other = true;
     }
-
+    //if the admin is trying to release someone else from their slot
     if(Auth::check() && (Auth::user()->hasRole('admin') || Auth::user()->hasRole('department-lead')))
     {
         $adminUrl = "/slot/{$slot->id}/adminRelease";


### PR DESCRIPTION
https://github.com/playasoft/volunteers/issues/222

this also fixes a bug when an admin tries to release themselves when pressing the green button, which should make the UX less frustrating. but also tells the admin when the accidentally added no user.