### PR TITLE
Allow event IDs to be passed from the login page

### DIFF
--- a/laravel/app/Http/Controllers/UserController.php
+++ b/laravel/app/Http/Controllers/UserController.php
@@ -70,6 +70,19 @@ class UserController extends Controller
             $user->save();
         }
 
+        // Check if an event ID was passed into the URL
+        $urlEvent = $request->get('event');
+
+        if(is_numeric($urlEvent))
+        {
+            $event = Event::find($urlEvent);
+
+            if(!empty($event))
+            {
+                return redirect('/event/' . $event->id);
+            }
+        }
+
         // Check if there's an ongoing or upcoming event to redirect the user to
         $event = Event::ongoingOrUpcoming();
 

--- a/laravel/resources/views/pages/login.blade.php
+++ b/laravel/resources/views/pages/login.blade.php
@@ -5,13 +5,15 @@
     <hr>
 
     {!! Form::open() !!}
+        <input type="hidden" name="event" value="{{ request()->get('event') }}">
+
         @include('partials/form/text', ['name' => 'name', 'label' => 'Username or Email', 'placeholder' => 'You can use your username or your email address'])
         @include('partials/form/password', ['name' => 'password', 'label' => 'Password', 'placeholder' => 'Your password'])
 
         <p>
             <a href="/forgot">Forgot password?</a>
         </p>
- 
+
         <button type="submit" class="btn btn-primary">Submit</button>
     {!! Form::close() !!}
 @endsection


### PR DESCRIPTION
This is useful when multiple events are running simultaneously and event coordinators want to provide a link to login to a specific event.

Fixes #234 